### PR TITLE
Support interrupting analysis via Thread.interrupt()

### DIFF
--- a/src/main/java/io/github/struppigel/parser/Interruption.scala
+++ b/src/main/java/io/github/struppigel/parser/Interruption.scala
@@ -1,0 +1,59 @@
+/**
+ * *****************************************************************************
+ * Copyright 2026 Karsten Hahn
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ****************************************************************************
+ */
+package io.github.struppigel.parser
+
+/**
+ * Thrown when a PE analysis is aborted because the executing thread was
+ * interrupted, e.g. via `Thread.interrupt()` by an embedding application
+ * that wants to cancel a long running analysis.
+ * <p>
+ * The thread's interrupt flag is intentionally left set when this exception
+ * is thrown, so that enclosing code that accidentally swallows the exception
+ * still aborts at the next interruption checkpoint.
+ * <p>
+ * A `PEData` instance whose computation was aborted by this exception may
+ * hold partially computed state and should be discarded.
+ */
+class AnalysisInterruptedException(message: String) extends RuntimeException(message) {
+  def this() = this("PE analysis aborted because the thread was interrupted")
+}
+
+/**
+ * Cooperative cancellation support for long running analysis loops.
+ * <p>
+ * Long running loops (full file scans, entropy calculation, per-entry
+ * parsing of attacker controlled structures) call `checkInterrupt()` once
+ * per chunk/entry/iteration. Blocking calls that throw
+ * `InterruptedException` must restore the interrupt flag with
+ * `Thread.currentThread().interrupt()` and then throw
+ * [[AnalysisInterruptedException]].
+ * <p>
+ * Callable from Java as `Interruption.checkInterrupt()`.
+ */
+object Interruption {
+
+  /**
+   * Throws [[AnalysisInterruptedException]] if the current thread has been
+   * interrupted. Never clears the interrupt flag (uses `isInterrupted`, not
+   * `Thread.interrupted()`), so repeated checks keep firing even if an
+   * intermediate catch block discards the exception.
+   */
+  @inline def checkInterrupt(): Unit =
+    if (Thread.currentThread().isInterrupted)
+      throw new AnalysisInterruptedException()
+}

--- a/src/main/java/io/github/struppigel/parser/Mapping.scala
+++ b/src/main/java/io/github/struppigel/parser/Mapping.scala
@@ -159,6 +159,8 @@ class Mapping(val virtRange: VirtRange, val physRange: PhysRange, private val da
     val bytes = zeroBytes(size)
     // get every single byte via apply, TODO could be done more efficiently
     for (i <- 0 until size) {
+      // i & 0x1fff == i % 8192, i.e. check for cancellation once every 8 KB
+      if ((i & 0x1fff) == 0) Interruption.checkInterrupt()
       bytes(i) = apply(virtOffset + i)
     }
     bytes

--- a/src/main/java/io/github/struppigel/parser/MemoryMappedPE.scala
+++ b/src/main/java/io/github/struppigel/parser/MemoryMappedPE.scala
@@ -228,6 +228,9 @@ class MemoryMappedPE(
    *         -1 if no byte satisfies the condition
    */
   def indexWhere(p: Byte => Boolean, from: Long): Long = {
+    // the searched range is the virtual space, which may be huge for
+    // malformed files, so allow cancellation once per chunk
+    Interruption.checkInterrupt()
     // no byte found, from exceeds MemoryMappedPE length, return -1
     if (from > length) -1
     else {

--- a/src/main/java/io/github/struppigel/parser/sections/idata/DelayLoadDirectoryEntry.scala
+++ b/src/main/java/io/github/struppigel/parser/sections/idata/DelayLoadDirectoryEntry.scala
@@ -23,7 +23,7 @@ import io.github.struppigel.parser.sections.SectionLoader.LoadInfo
 import DelayLoadDirectoryEntry._
 import DelayLoadDirectoryKey._
 import io.github.struppigel.parser.optheader.WindowsEntryKey
-import io.github.struppigel.parser.{IOUtil, StandardField}
+import io.github.struppigel.parser.{IOUtil, Interruption, StandardField}
 import io.github.struppigel.parser.{MemoryMappedPE, PhysicalLocation}
 import org.apache.logging.log4j.LogManager
 
@@ -169,6 +169,9 @@ object DelayLoadDirectoryEntry {
       case UNKNOWN => throw new IllegalArgumentException("Unknown magic number, can not parse delay-load imports")
     }
     do {
+      // this loop runs until a null entry is found, which a malformed file
+      // may never provide, so allow cancellation
+      Interruption.checkInterrupt()
       //TODO get fileoffset for entry from mmbytes instead of this to avoid fractionated section issues ?
       val entryFileOffset = fileOffset + offset
       //val entryFileOffset = mmbytes.getPhysforVir(iRVA) //doesn't work

--- a/src/main/java/io/github/struppigel/parser/sections/idata/ImportSection.scala
+++ b/src/main/java/io/github/struppigel/parser/sections/idata/ImportSection.scala
@@ -22,7 +22,7 @@ import io.github.struppigel.parser.optheader.OptionalHeader.MagicNumber._
 import io.github.struppigel.parser.sections.SectionLoader.LoadInfo
 import DirectoryEntryKey._
 import io.github.struppigel.parser.optheader.{OptionalHeader, WindowsEntryKey}
-import io.github.struppigel.parser.{PEData, PELoader}
+import io.github.struppigel.parser.{Interruption, PEData, PELoader}
 import io.github.struppigel.parser.sections.{SectionLoader, SpecialSection}
 import io.github.struppigel.parser.{Location, MemoryMappedPE, PhysicalLocation}
 import org.apache.logging.log4j.LogManager
@@ -167,9 +167,10 @@ object ImportSection {
         case UNKNOWN => throw new IllegalArgumentException("Unknown magic number")
       }
       do {
+        Interruption.checkInterrupt()
         //TODO get fileoffset for entry from mmbytes instead of this to avoid
         //fractionated section issues ?
-        val entryFileOffset = fileOffset + offset 
+        val entryFileOffset = fileOffset + offset
 //        val entryFileOffset = mmbytes.getPhysforVir(iRVA) //doesn't work
         entry = LookupTableEntry(loadInfo, mmbytes, offset.toInt, EntrySize,
             virtualAddress, relOffset, iVA, dirEntry, entryFileOffset)
@@ -195,6 +196,7 @@ object ImportSection {
     var i = 0
     val dirEntryMax = 10000
     do {
+      Interruption.checkInterrupt()
       logger.debug(s"reading ${i + 1}. entry")
       readDirEntry(i, mmbytes, virtualAddress, fileOffset) match {
         case Some(entry) =>

--- a/src/main/java/io/github/struppigel/parser/sections/idata/LookupTableEntry.scala
+++ b/src/main/java/io/github/struppigel/parser/sections/idata/LookupTableEntry.scala
@@ -20,7 +20,7 @@ package io.github.struppigel.parser.sections.idata
 import LookupTableEntry._
 import io.github.struppigel.parser.optheader.WindowsEntryKey
 import io.github.struppigel.parser.sections.SectionLoader.LoadInfo
-import io.github.struppigel.parser.{MemoryMappedPE, PhysicalLocation}
+import io.github.struppigel.parser.{AnalysisInterruptedException, MemoryMappedPE, PhysicalLocation}
 import org.apache.logging.log4j.LogManager
 
 import java.lang.Long.toHexString
@@ -151,6 +151,8 @@ object LookupTableEntry {
           case _ : FailureEntryException => createNameEntry(loadInfo, value, mmbytes, iltRVA, iltVA, dirEntry, entrySize, fileOffset, true)
         }
     } catch {
+      // interruption must abort the analysis, not be logged as a failed entry
+      case e: AnalysisInterruptedException => throw e
       case e: Exception =>
         val message = "invalid lookup table entry at ilt rva " + iltRVA + ", reason: " + e.getMessage()
         logger.warn(message)

--- a/src/main/java/io/github/struppigel/parser/sections/rsrc/ResourceDirectory.scala
+++ b/src/main/java/io/github/struppigel/parser/sections/rsrc/ResourceDirectory.scala
@@ -20,7 +20,7 @@ package io.github.struppigel.parser.sections.rsrc
 import io.github.struppigel.parser.IOUtil.SpecificationFormat
 import ResourceDirectory._
 import ResourceDirectoryKey._
-import io.github.struppigel.parser.{IOUtil, StandardField}
+import io.github.struppigel.parser.{IOUtil, Interruption, StandardField}
 import io.github.struppigel.parser.{MemoryMappedPE, PhysicalLocation}
 import org.apache.logging.log4j.LogManager
 
@@ -286,6 +286,7 @@ object ResourceDirectory {
     val offsets: ListBuffer[Long] = scala.collection.mutable.ListBuffer.empty
     try {
       for (i <- 0 until limitedEntriesSum) {
+        Interruption.checkInterrupt()
         // calculate the offset for the entry
         val offset = resourceDirSize + i * entrySize + virtualAddress + rsrcDirRVA
         // the offset to the end of the entry

--- a/src/main/java/io/github/struppigel/tools/ChiSquared.scala
+++ b/src/main/java/io/github/struppigel/tools/ChiSquared.scala
@@ -2,7 +2,7 @@ package io.github.struppigel.tools
 
 import io.github.struppigel.parser.ScalaIOUtil.using
 import ChiSquared.calculate
-import io.github.struppigel.parser.{PEData, PELoader}
+import io.github.struppigel.parser.{Interruption, PEData, PELoader}
 import io.github.struppigel.parser.sections.SectionLoader
 
 import java.io.{File, RandomAccessFile}
@@ -124,13 +124,17 @@ object ChiSquared {
     // initialize total
     var total: Long = 0L
     // count each byte in the given array
-    bytes.toList.foreach { byte =>
+    var i = 0
+    while (i < bytes.length) {
+      // the array may cover a whole file or overlay, so allow cancellation
+      if ((i & 0x1fff) == 0) Interruption.checkInterrupt()
       // byte to int conversion
-      val index = byte & 0xff
+      val index = bytes(i) & 0xff
       // count byte, index denotes the read byte value
       byteCounts(index) += 1L
       // add byte to total
       total += 1L
+      i += 1
     }
     // return our tuple
     (byteCounts, total)
@@ -168,6 +172,8 @@ object ChiSquared {
         }
         // count bytes for each chunk
         .foreach { bytesRead =>
+          // one cancellation checkpoint per chunk read from file
+          Interruption.checkInterrupt()
           // take only the bytes that were actually read
           val bytes = chunk.toList.take(bytesRead)
           // count each byte that is within the specified range

--- a/src/main/java/io/github/struppigel/tools/PEAutoRepair.scala
+++ b/src/main/java/io/github/struppigel/tools/PEAutoRepair.scala
@@ -1,6 +1,6 @@
 package io.github.struppigel.tools
 
-import io.github.struppigel.parser.{IOUtil, PELoader, PESignature}
+import io.github.struppigel.parser.{AnalysisInterruptedException, IOUtil, PELoader, PESignature}
 import io.github.struppigel.parser.ScalaIOUtil.using
 import io.github.struppigel.parser.msdos.MSDOSHeader
 
@@ -56,7 +56,8 @@ class PEAutoRepair(private val inFile: File, private val outFile: File) {
     try {
        PELoader.loadPE(outFile)
     } catch {
-      case e: Exception => return false 
+      case e: AnalysisInterruptedException => throw e
+      case e: Exception => return false
     }
     true
   }

--- a/src/main/java/io/github/struppigel/tools/ShannonEntropy.scala
+++ b/src/main/java/io/github/struppigel/tools/ShannonEntropy.scala
@@ -19,7 +19,7 @@ package io.github.struppigel.tools
 
 import io.github.struppigel.parser.ScalaIOUtil.using
 import ShannonEntropy._
-import io.github.struppigel.parser.{PEData, PELoader}
+import io.github.struppigel.parser.{Interruption, PEData, PELoader}
 import io.github.struppigel.parser.sections.SectionLoader
 
 import java.io.{File, RandomAccessFile}
@@ -158,13 +158,17 @@ object ShannonEntropy {
     // initialize total
     var total: Long = 0L
     // count each byte in the given array
-    bytes.toList.foreach { byte =>
+    var i = 0
+    while (i < bytes.length) {
+      // the array may cover a whole file or overlay, so allow cancellation
+      if ((i & 0x1fff) == 0) Interruption.checkInterrupt()
       // byte to int conversion
-      val index = byte & 0xff
+      val index = bytes(i) & 0xff
       // count byte, index denotes the read byte value
       byteCounts(index) += 1L
       // add byte to total
       total += 1L
+      i += 1
     }
     // return our tuple
     (byteCounts, total)
@@ -211,6 +215,8 @@ object ShannonEntropy {
         }
         // count bytes for each chunk
         .foreach { bytesRead =>
+          // one cancellation checkpoint per chunk read from file
+          Interruption.checkInterrupt()
           // take only the bytes that were actually read
           val bytes = chunk.toList.take(bytesRead)
           // count each byte that is within the specified range

--- a/src/main/java/io/github/struppigel/tools/StringExtractor.scala
+++ b/src/main/java/io/github/struppigel/tools/StringExtractor.scala
@@ -17,6 +17,7 @@
  */
 package io.github.struppigel.tools
 
+import io.github.struppigel.parser.Interruption
 import io.github.struppigel.parser.ScalaIOUtil.using
 
 import java.io._
@@ -73,6 +74,7 @@ object StringExtractor {
       var byte: Int = is.read()
       // until EOF
       while (byte != -1 && strings.size < maxNumber) {
+        Interruption.checkInterrupt()
         // drop all bytes that are not ascii
         byte = dropWhile(is, !isASCIIPrintable(_))
         // check for EOF
@@ -102,6 +104,7 @@ object StringExtractor {
     val str = new StringBuffer()
     // read and save bytes as long as they fulfill f
     while (byte != -1 && f(byte)) {
+      Interruption.checkInterrupt()
       str.append(byte.toChar)
       byte = is.read()
     }
@@ -114,6 +117,7 @@ object StringExtractor {
     var byte: Int = is.read()
     // read bytes as long as they fulfill f
     while (byte != -1 && f(byte)) {
+      Interruption.checkInterrupt()
       byte = is.read()
     }
     // return last read value, which does not fulfill f
@@ -149,6 +153,7 @@ object StringExtractor {
       if (readInt != -1) codepoints += readInt
       var prev = 0
       while (readInt != -1 && strings.size < maxNumber) {
+        Interruption.checkInterrupt()
         if (readInt == 0) {
           maybeAppendToResults(codepoints)
           codepoints = ListBuffer.empty[Int]

--- a/src/main/java/io/github/struppigel/tools/anomalies/OverlayScanning.scala
+++ b/src/main/java/io/github/struppigel/tools/anomalies/OverlayScanning.scala
@@ -2,6 +2,7 @@ package io.github.struppigel.tools.anomalies
 
 import scala.collection.mutable.ListBuffer
 import io.github.struppigel.parser.IOUtil._
+import io.github.struppigel.parser.Interruption
 import io.github.struppigel.tools.Overlay
 import scala.collection.JavaConverters._
 import io.github.struppigel.tools.sigscanner.{FileTypeScanner, Signature, SignatureScanner}
@@ -43,8 +44,10 @@ trait OverlayScanning extends AnomalyScanner {
       val offset = rdata.getAlignedPointerToRaw(false)
       val size = Math.min(maxScanSize, rdata.getAlignedSizeOfRaw(false))
       val end = offset + Math.min(data.getFile.length(), size)
+      val scanner = new SignatureScanner(List(signature))
       for(i <- offset until end) {
-        val results = new SignatureScanner(List(signature)).scanAt(data.getFile, i)
+        Interruption.checkInterrupt()
+        val results = scanner.scanAt(data.getFile, i)
         if (!results.isEmpty) {
           return List(GenericReHintAnomaly("'PyInstaller archive' string in .rdata"))
         }

--- a/src/main/java/io/github/struppigel/tools/sigscanner/Jar2ExeScanner.scala
+++ b/src/main/java/io/github/struppigel/tools/sigscanner/Jar2ExeScanner.scala
@@ -20,10 +20,10 @@ package io.github.struppigel.tools.sigscanner
 import io.github.struppigel.parser.ScalaIOUtil.using
 import Jar2ExeScanner._
 import SignatureScanner.{Address, ScanResult}
-import io.github.struppigel.parser.IOUtil
+import io.github.struppigel.parser.{AnalysisInterruptedException, IOUtil}
 
 import java.io.{File, FileOutputStream, RandomAccessFile}
-import java.nio.channels.Channels
+import java.nio.channels.{Channels, ClosedByInterruptException}
 import java.util.zip.ZipInputStream
 import scala.collection.JavaConverters.seqAsJavaListConverter
 import scala.collection.mutable.ListBuffer
@@ -78,6 +78,10 @@ class Jar2ExeScanner(file: File) {
         e = zis.getNextEntry()
       }
     } catch {
+      // the zip is read through an interruptible channel: interruption of the
+      // analysis thread must abort the scan instead of being swallowed
+      case e: ClosedByInterruptException  => throw new AnalysisInterruptedException()
+      case e: AnalysisInterruptedException => throw e
       case e: IllegalArgumentException => return Nil
       case e: Exception                => //System.err.println(e.getMessage())
     } finally {

--- a/src/main/java/io/github/struppigel/tools/sigscanner/SignatureScanner.scala
+++ b/src/main/java/io/github/struppigel/tools/sigscanner/SignatureScanner.scala
@@ -21,7 +21,7 @@ import io.github.struppigel.parser.ScalaIOUtil.{bytes2hex, using}
 import io.github.struppigel.parser.optheader.StandardFieldEntryKey._
 import SignatureScanner._
 import io.github.struppigel.parser.sections.SectionLoader
-import io.github.struppigel.parser.{FileFormatException, IOUtil, PELoader}
+import io.github.struppigel.parser.{FileFormatException, IOUtil, Interruption, PELoader}
 import io.github.struppigel.parser.ScalaIOUtil
 import org.apache.logging.log4j.LogManager
 
@@ -159,6 +159,7 @@ class SignatureScanner(signatures: List[Signature]) {
     using(new RandomAccessFile(file, "r")) { raf =>
       val results = ListBuffer[ScanResult]()
       for (addr <- 0L to file.length()) {
+        Interruption.checkInterrupt()
         val bytes = Array.fill(longestSigSequence + 1)(0.toByte)
         raf.seek(addr)
         val bytesRead = raf.read(bytes)

--- a/src/main/java/io/github/struppigel/tools/sigscanner/v2/ScanLocationScanner.scala
+++ b/src/main/java/io/github/struppigel/tools/sigscanner/v2/ScanLocationScanner.scala
@@ -16,7 +16,7 @@ package io.github.struppigel.tools.sigscanner.v2
  * limitations under the License.
  ******************************************************************************/
 import io.github.struppigel.parser.ScalaIOUtil.using
-import io.github.struppigel.parser.{IOUtil, PEData}
+import io.github.struppigel.parser.{IOUtil, Interruption, PEData}
 import io.github.struppigel.parser.optheader.StandardFieldEntryKey.ADDR_OF_ENTRY_POINT
 import io.github.struppigel.parser.sections.SectionLoader
 import io.github.struppigel.tools.Overlay
@@ -51,7 +51,9 @@ abstract class SingleScanLocationScanner extends ScanLocationScanner {
     if(!locationExists(pe)) return Nil
     val bytes = getLocationBytes(pe)
     val absoluteOffset = getLocationStart(pe)
-    signatures.filter(_.matches(bytes)._1).map(s => (s, s.matches(bytes)._2 + absoluteOffset))
+    // one checkpoint per signature, since the pattern matcher may backtrack a lot
+    signatures.filter { s => Interruption.checkInterrupt(); s.matches(bytes)._1 }
+      .map(s => (s, s.matches(bytes)._2 + absoluteOffset))
   }
 }
 

--- a/src/main/java/io/github/struppigel/tools/visualizer/Visualizer.java
+++ b/src/main/java/io/github/struppigel/tools/visualizer/Visualizer.java
@@ -20,6 +20,7 @@ import io.github.struppigel.parser.coffheader.COFFFileHeader;
 import io.github.struppigel.parser.optheader.DataDirectoryKey;
 import io.github.struppigel.parser.optheader.StandardFieldEntryKey;
 import io.github.struppigel.parser.sections.*;
+import io.github.struppigel.parser.Interruption;
 import io.github.struppigel.parser.Location;
 import io.github.struppigel.parser.PhysicalLocation;
 import io.github.struppigel.parser.sections.clr.CLRSection;
@@ -148,6 +149,7 @@ public class Visualizer {
 		final long minLength = withMinLength(0);
 		try (RandomAccessFile raf = new RandomAccessFile(file, "r")) {
 			for (long address = 0; address < fileSize; address += minLength) {
+				Interruption.checkInterrupt();
 				raf.seek(address);
 				byte b = raf.readByte();
 				Color color = getBytePlotColor(b);
@@ -240,6 +242,7 @@ public class Visualizer {
 		try (RandomAccessFile raf = new RandomAccessFile(file, "r")) {
 			// read until EOF with windowSized steps
 			for (long address = 0; address <= fileSize; address += minLength) {
+				Interruption.checkInterrupt();
 				// the start of the window (windowHalf to the left)
 				long start = (address - windowHalfSize < 0) ? 0 : address
 						- windowHalfSize;

--- a/src/test/java/io/github/struppigel/InterruptionTest.java
+++ b/src/test/java/io/github/struppigel/InterruptionTest.java
@@ -1,0 +1,146 @@
+package io.github.struppigel;
+
+import io.github.struppigel.parser.AnalysisInterruptedException;
+import io.github.struppigel.parser.Interruption;
+import io.github.struppigel.tools.ChiSquared;
+import io.github.struppigel.tools.ShannonEntropy;
+import io.github.struppigel.tools.StringExtractor;
+import io.github.struppigel.tools.sigscanner.SignatureScanner;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.testng.Assert.*;
+
+/**
+ * Verifies that long running analysis loops abort promptly with
+ * {@link AnalysisInterruptedException} when the executing thread is
+ * interrupted, and that the interrupt flag is preserved.
+ */
+public class InterruptionTest {
+
+    private File randomFile;
+
+    @BeforeClass
+    public void createTestFile() throws IOException {
+        randomFile = File.createTempFile("portex-interruption-test", ".bin");
+        randomFile.deleteOnExit();
+        byte[] chunk = new byte[8192];
+        Random rand = new Random(42);
+        try (FileOutputStream out = new FileOutputStream(randomFile)) {
+            for (int i = 0; i < 1024; i++) { // 8 MB of random bytes
+                rand.nextBytes(chunk);
+                out.write(chunk);
+            }
+        }
+    }
+
+    @AfterClass
+    public void deleteTestFile() {
+        randomFile.delete();
+    }
+
+    @AfterMethod
+    public void clearInterruptFlag() {
+        // do not let a leftover flag poison other tests
+        Thread.interrupted();
+    }
+
+    /**
+     * Runs the action with the interrupt flag pre-set and asserts it aborts
+     * with AnalysisInterruptedException while keeping the flag set.
+     */
+    private void assertAbortsWhenInterrupted(Runnable action) {
+        Thread.currentThread().interrupt();
+        try {
+            action.run();
+            fail("expected AnalysisInterruptedException");
+        } catch (AnalysisInterruptedException e) {
+            assertTrue(Thread.currentThread().isInterrupted(),
+                    "interrupt flag must stay set");
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    @Test
+    public void checkInterruptIsNoopWithoutInterrupt() {
+        assertFalse(Thread.currentThread().isInterrupted());
+        Interruption.checkInterrupt(); // must not throw
+    }
+
+    @Test
+    public void checkInterruptThrowsAndPreservesFlag() {
+        assertAbortsWhenInterrupted(() -> Interruption.checkInterrupt());
+    }
+
+    @Test
+    public void entropyFileScanAborts() {
+        assertAbortsWhenInterrupted(() ->
+                ShannonEntropy.entropy(randomFile, 0, randomFile.length()));
+    }
+
+    @Test
+    public void entropyArrayScanAborts() {
+        byte[] bytes = new byte[1024 * 1024];
+        assertAbortsWhenInterrupted(() -> ShannonEntropy.entropy(bytes));
+    }
+
+    @Test
+    public void chiSquaredFileScanAborts() {
+        assertAbortsWhenInterrupted(() ->
+                ChiSquared.calculate(randomFile, 0, randomFile.length()));
+    }
+
+    @Test
+    public void chiSquaredArrayScanAborts() {
+        byte[] bytes = new byte[1024 * 1024];
+        assertAbortsWhenInterrupted(() -> ChiSquared.calculate(bytes));
+    }
+
+    @Test
+    public void signatureFullFileScanAborts() {
+        SignatureScanner scanner = SignatureScanner.newInstance();
+        assertAbortsWhenInterrupted(() ->
+                scanner.findAllEPFalseMatches(randomFile));
+    }
+
+    @Test
+    public void stringExtractorAborts() {
+        assertAbortsWhenInterrupted(() ->
+                StringExtractor.readASCIIStrings(randomFile, 4));
+    }
+
+    /**
+     * Integration style test: interrupt a worker mid-scan and require it to
+     * stop within a bounded time. The full-file signature scan on 8 MB of
+     * random data takes far longer than the interrupt delay.
+     */
+    @Test
+    public void runningFullFileScanStopsPromptlyOnInterrupt()
+            throws InterruptedException {
+        SignatureScanner scanner = SignatureScanner.newInstance();
+        AtomicReference<Throwable> thrown = new AtomicReference<>();
+        Thread worker = new Thread(() -> {
+            try {
+                scanner.findAllEPFalseMatches(randomFile);
+            } catch (Throwable t) {
+                thrown.set(t);
+            }
+        });
+        worker.start();
+        Thread.sleep(200); // let the scan get into the hot loop
+        worker.interrupt();
+        worker.join(5000);
+        assertFalse(worker.isAlive(), "worker must stop after interrupt");
+        assertTrue(thrown.get() instanceof AnalysisInterruptedException,
+                "expected AnalysisInterruptedException but got: " + thrown.get());
+    }
+}


### PR DESCRIPTION
**Why**

There is currently no way to cancel an analysis once it has started. On large or deliberately malformed PE files, some loops can run for a long time. An embedding app that wants to abort (user cancels, timeout, shutdown) has no option but to let the analysis run to completion or kill the whole process.

**What is done**

Cancellation support via standard `Thread.interrupt()`:
- A new `Interruption.checkInterrupt()` helper is called at safe points inside the long-running loops.
- If the executing thread has been interrupted, it throws `AnalysisInterruptedException` and the analysis stops cleanly. 
- Calling code interrupts the analysis thread as usual.

The interrupt flag is intentionally left set when the exception is thrown, so that any enclosing code which accidentally swallows it still aborts at the next checkpoint.